### PR TITLE
ランダムカラーの高難易度版実装

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -81,17 +81,6 @@ Future<void> main() async {
     moveAlarm = true;
     if (moveAlarm != true) moveAlarm = true;
     loadSettingData();
-    /*
-    Alarm alarm = await getAlarm();
-    final SendPort send = IsolateNameServer.lookupPortByName(sendPortName);
-    List<dynamic> list = [
-      appSetting.movingAlarmId,
-      alarm.vibration,
-      appSetting.volume,
-      true
-    ];
-    send?.send(list);
-    */
     BuildContext context;
     Navigator.pushNamedAndRemoveUntil(context, "/", (_) => false);
   });

--- a/lib/module/shared_prefs.dart
+++ b/lib/module/shared_prefs.dart
@@ -64,7 +64,8 @@ loadSettingData({bool needReturn = false}) async {
         feastAlarmTime: initDateTime,
         volume: 1.0,
         useQuiz: intList,
-        quizClearCount: 3);
+        quizClearCount: 3,
+        colorCodeQuiz: false);
     print('設定データ読み込み失敗');
   }
   appSetting = settings;

--- a/lib/module/user_setting.dart
+++ b/lib/module/user_setting.dart
@@ -11,20 +11,24 @@ class UserSetting {
   List<bool> useQuiz;
   //スヌーズ解除の為の問題の数
   int quizClearCount = 3;
+  //ランダムカラーの選択肢がカラーコードか否か
+  bool colorCodeQuiz;
 
   UserSetting(
       {this.movingAlarmId,
       this.feastAlarmTime,
       this.volume,
       this.useQuiz,
-      this.quizClearCount});
+      this.quizClearCount,
+      this.colorCodeQuiz});
 
   Map toJson() => {
         'movingAlarmId': movingAlarmId,
         'feastAlarmTime': '$feastAlarmTime',
         'volume': volume,
         'useQuiz': useQuiz,
-        'quizClearCount': quizClearCount
+        'quizClearCount': quizClearCount,
+        'colorCodeQuiz': colorCodeQuiz
       };
 
   UserSetting.fromJson(Map json)
@@ -32,7 +36,8 @@ class UserSetting {
         feastAlarmTime = tz.TZDateTime.parse(tz.local, json['feastAlarmTime']),
         volume = json['volume'],
         useQuiz = json['useQuiz'].cast<bool>() as List<bool>,
-        quizClearCount = json['quizClearCount'];
+        quizClearCount = json['quizClearCount'],
+        colorCodeQuiz = json['colorCodeQuiz'];
 }
 
 UserSetting appSetting;

--- a/lib/screen/mainmenu.dart
+++ b/lib/screen/mainmenu.dart
@@ -124,7 +124,7 @@ class _MainMenuState extends State<MainMenu> {
                           crossAxisAlignment: CrossAxisAlignment.center,
                           mainAxisAlignment: MainAxisAlignment.start,
                           children: <Widget>[
-                            /*クイズ検証用ショトカ
+                            /*クイズ検証用ショトカ下のボタンをコメントアウトから戻してね
                             RaisedButton(
                               child: Text('QuizTest'),
                               onPressed: () {

--- a/lib/screen/setting.dart
+++ b/lib/screen/setting.dart
@@ -128,6 +128,10 @@ class _SettingState extends State<Setting> {
                         fontWeight: FontWeight.bold,
                         color: Colors.red)),
               buildQuizCheckBox(),
+              heightSpacer(height: size.height * 0.01),
+              AutoSizeText('クイズの難易度アップオプション',
+                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+              buildColorCodeQuizSwitch(),
             ],
           ),
         ),
@@ -191,6 +195,29 @@ class _SettingState extends State<Setting> {
                 }),
           ),
       ],
+    );
+  }
+
+  buildColorCodeQuizSwitch() {
+    return Container(
+      decoration: borderLine,
+      child: SizedBox(
+        child: SwitchListTile(
+          value: appSetting.colorCodeQuiz,
+          title: AutoSizeText(
+            'ランダムカラーの色名のカラーコード化',
+            style: TextStyle(fontWeight: FontWeight.w500),
+            minFontSize: 15,
+          ),
+          onChanged: (bool value) {
+            setState(() {
+              appSetting.colorCodeQuiz = value;
+            });
+            deleteSettingData();
+            saveSettingData(appSetting);
+          },
+        ),
+      ),
     );
   }
 }

--- a/lib/screen/snoozestop.dart
+++ b/lib/screen/snoozestop.dart
@@ -355,7 +355,7 @@ class _SnoozeStopState extends State<SnoozeStop> {
                 },
                 child: (appSetting.colorCodeQuiz)
                     ? Text(
-                        '${randomColor[i].red.toRadixString(16).toUpperCase()}${randomColor[i].green.toRadixString(16).toUpperCase()}${randomColor[i].blue.toRadixString(16).toUpperCase()}',
+                        '#${randomColor[i].red.toRadixString(16).toUpperCase()}${randomColor[i].green.toRadixString(16).toUpperCase()}${randomColor[i].blue.toRadixString(16).toUpperCase()}',
                         style: TextStyle(fontSize: 20))
                     : Text('${randomColorName[i]}',
                         style: TextStyle(fontSize: 20)),

--- a/lib/screen/snoozestop.dart
+++ b/lib/screen/snoozestop.dart
@@ -311,19 +311,7 @@ class _SnoozeStopState extends State<SnoozeStop> {
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           heightSpacer(height: size.height * 0.05),
-          /*
-          Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                AutoSizeText('あと${(appSetting.quizClearCount - quizClearCount)}問',
-                    style: TextStyle(
-                      fontSize: 25,
-                      fontWeight: FontWeight.bold,
-                    )),
-                widthSpacer(width: size.width * 0.1),
-              ]),
-              */
+
           AutoSizeText(
             'Q.下の四角形の中の色を答えてください',
             style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
@@ -360,10 +348,17 @@ class _SnoozeStopState extends State<SnoozeStop> {
                       mistakeText = '不正解！';
                       quizMistake = true;
                     });
+                    if (appSetting.colorCodeQuiz)
+                      print(
+                          '正解は、${trueColor.red.toRadixString(16).toUpperCase()}${trueColor.green.toRadixString(16).toUpperCase()}${trueColor.blue.toRadixString(16).toUpperCase()}');
                   }
                 },
-                child: Text('${randomColorName[i]}',
-                    style: TextStyle(fontSize: 20)),
+                child: (appSetting.colorCodeQuiz)
+                    ? Text(
+                        '${randomColor[i].red.toRadixString(16).toUpperCase()}${randomColor[i].green.toRadixString(16).toUpperCase()}${randomColor[i].blue.toRadixString(16).toUpperCase()}',
+                        style: TextStyle(fontSize: 20))
+                    : Text('${randomColorName[i]}',
+                        style: TextStyle(fontSize: 20)),
               ),
             ),
         ]);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.1.0
+version: 1.1.1
 
 environment:
   sdk: ">=2.7.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.1.1
+version: 1.1.1+2
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
- 設定画面に高難易度化オプションを追加
- ランダムカラーの選択肢がカラーコード表示にできるよう機能追加
  - 設定画面のボタン追加
  - 機能がオンになっている場合のランダムカラーの選択枝の表示が「#ABCDEF」のように変更
- 上記の機能追加に伴いアプリのバージョンをアップ